### PR TITLE
Update extension extraction to account for query params

### DIFF
--- a/packages/gephi-lite/src/core/file/utils.ts
+++ b/packages/gephi-lite/src/core/file/utils.ts
@@ -53,7 +53,7 @@ export async function extractGraphFromFile(
     }
   | { format: "gephi-lite"; data: GephiLiteFileFormat; metadata?: undefined }
 > {
-  const extension = (fileName.split(".").pop() || "").toLowerCase();
+  const extension = (fileName.split("?").shift().split(".").pop() || "").toLowerCase();
 
   // Based on file extension, parse it to build a graphology
   switch (extension) {


### PR DESCRIPTION
Some remote files have query params, such as a pre-signed url for a cloud hosted storage bucket. This updates the extension extraction to exclude anything after the ? mark.

## Pull request type

Check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

> **_NOTE:_** Try to limit your pull request to one type, submit multiple pull requests if needed.

## What is the current behavior?

Error is thrown:
`GephiLiteError: Extension graphml?sp=r&st=2025-11-15t17:54:03z&se=2025-11-15t19:09:03z..... for file cmhzgzmxe0001jg01tz2spvp4.graphml?sp=r&st=2025-11-15T17:54:03Z&se=2025-11-15T19:09:03Z...... is not recognized`

## What is the new behavior?

The `extractGraphFromFile` should exclude characters after the `?` query params when it is extracting the file extension, which it then uses to construct the Graphology object.

## Other information

> **_NOTE:_** Any other information that is important to this PR such as screenshots of how the component looks before and after the change.
