### PR TITLE
[gephi-lite] adding layout controller on graph

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "lerna": "^8.2.0",
         "playwright": "^1.50.1",
         "prettier": "^3.4.2",
+        "react-what-changed": "^1.1.2",
         "rimraf": "^6.0.1",
         "typescript": "^5.7.3",
         "typescript-eslint": "^8.22.0",
@@ -17108,6 +17109,16 @@
       "peerDependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
+      }
+    },
+    "node_modules/react-what-changed": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/react-what-changed/-/react-what-changed-1.1.2.tgz",
+      "integrity": "sha512-uICi+PGfaOVl70BrZrNwOko19kMS11WBKef1i1d37Utsx+N9Zvu04V3hDxeTOexJziIi1+Q1Ok8+7NnvrGPzHA==",
+      "dev": true,
+      "license": "Apache 2.0",
+      "engines": {
+        "node": ">=13.0.0"
       }
     },
     "node_modules/reactcss": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "lerna": "^8.2.0",
     "playwright": "^1.50.1",
     "prettier": "^3.4.2",
+    "react-what-changed": "^1.1.2",
     "rimraf": "^6.0.1",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.22.0",

--- a/packages/gephi-lite/src/components/Loader.tsx
+++ b/packages/gephi-lite/src/components/Loader.tsx
@@ -23,8 +23,9 @@ export const Loader: FC = () => (
 /**
  * Display a loader that takes the size of its parent container.
  */
-export const LoaderFill: FC = () => (
+export const LoaderFill: FC<{ message?: string }> = ({ message }) => (
   <div className="loader-fill">
     <Spinner style={{ width: "3rem", height: " 3rem" }} />
+    {message && <p className="text-center">{message}</p>}
   </div>
 );

--- a/packages/gephi-lite/src/components/SideMenu.tsx
+++ b/packages/gephi-lite/src/components/SideMenu.tsx
@@ -7,6 +7,7 @@ import { IconType } from "react-icons";
 import TetherComponent from "react-tether";
 
 import { CaretDownIcon, CaretRightIcon } from "./common-icons";
+import { Spinner } from "./Loader";
 
 type MenuCommon<T = unknown> = {
   id: string;
@@ -22,17 +23,18 @@ type MenuCommon<T = unknown> = {
     }
 ) &
   T;
-type MenuButton<T> = MenuCommon<T> & { type?: "button" };
+type MenuButton<T> = MenuCommon<T> & { type?: "button" , isRunning?:boolean};
 type MenuText<T> = MenuCommon<T> & { type: "text"; className?: string };
 type MenuSimpleItem<T> = MenuButton<T> | MenuText<T>;
-type MenuSection<T> = MenuSimpleItem<T> & { children: MenuSimpleItem<T>[] };
+export type MenuSection<T> = MenuSimpleItem<T> & { children: MenuSimpleItem<T>[] };
 export type MenuItem<T = unknown> = MenuSimpleItem<T> | MenuSection<T>;
 
-const ItemMenuInner: FC<{ item: MenuItem; isOpened?: boolean; isSelected?: boolean }> = ({
+const ItemMenuInner: FC<{ item: MenuItem; isOpened?: boolean; isSelected?: boolean, isLoading? :boolean }> = ({
   item,
   isOpened,
   isSelected,
-}) => {
+  isLoading
+}) =>{
   const { t } = useTranslation();
   return (
     <div className="d-flex align-items-center w-100">
@@ -46,6 +48,7 @@ const ItemMenuInner: FC<{ item: MenuItem; isOpened?: boolean; isSelected?: boole
           <span className="side-menu-item">{item.capitalize ? capitalize(t(item.i18nKey)) : t(item.i18nKey)}</span>
         </>
       )}
+      {isLoading && (<Spinner className="spinner-border-sm ms-2"/>)}
       {isOpened !== undefined && <span>{isOpened ? <CaretDownIcon /> : <CaretRightIcon />}</span>}
     </div>
   );
@@ -69,7 +72,7 @@ function SimpleItem<T = unknown>({
       className={cx("gl-btn w-100 text-start", selected === item.id && "gl-btn-fill")}
       onClick={() => onSelectedChange(item)}
     >
-      <ItemMenuInner item={item} isSelected={selected === item.id} />
+      <ItemMenuInner item={item} isSelected={selected === item.id} isLoading={item.isRunning}/>
     </button>
   );
 }

--- a/packages/gephi-lite/src/components/common-icons.tsx
+++ b/packages/gephi-lite/src/components/common-icons.tsx
@@ -58,6 +58,8 @@ import {
   PiPaintBrush,
   PiPalette,
   PiPaletteFill,
+  PiPause,
+  PiPauseFill,
   PiPencilSimpleLine,
   PiPencilSimpleLineFill,
   PiPlay,
@@ -71,6 +73,8 @@ import {
   PiSelection,
   PiSelectionBold,
   PiSignIn,
+  PiSkipForwardFill,
+  PiSkipForwardLight,
   PiSpinner,
   PiSquare,
   PiStop,
@@ -152,6 +156,10 @@ export const MouseIconFill = PiCursorFill;
 export const OpenInGraphIcon = PiCrosshair;
 export const PlayIcon = PiPlay;
 export const PlayIconFill = PiPlayFill;
+export const PlaySyncIcon = PiSkipForwardLight;
+export const PlaySyncIconFill = PiSkipForwardFill;
+export const PauseIcon = PiPause;
+export const PauseIconFill = PiPauseFill;
 export const ResetIcon = PiArrowCounterClockwise;
 export const RetryIcon = PiArrowClockwise;
 export const SearchIcon = PiMagnifyingGlass;

--- a/packages/gephi-lite/src/components/forms/LayoutQualityForm.tsx
+++ b/packages/gephi-lite/src/components/forms/LayoutQualityForm.tsx
@@ -1,12 +1,18 @@
-import { FC } from "react";
+import { FC, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 
-import { useLayoutActions, useLayoutState } from "../../core/context/dataContexts";
+import { useLayoutActions, useLayoutState, useSessionActions } from "../../core/context/dataContexts";
 
 export const LayoutQualityForm: FC = () => {
   const { t } = useTranslation();
-  const { quality } = useLayoutState();
-  const { setQuality } = useLayoutActions();
+  const { setLastLayout } = useSessionActions();
+  const layoutState = useLayoutState();
+  const { setQuality, stopLayout } = useLayoutActions();
+
+  useEffect(() => {
+    setLastLayout("layout-quality");
+    if (layoutState.type === "running") stopLayout();
+  }, [layoutState, stopLayout, setLastLayout]);
 
   return (
     <div className="panel-body">
@@ -24,9 +30,9 @@ export const LayoutQualityForm: FC = () => {
           <input
             className="form-check-input"
             id="qualityEnabled"
-            checked={quality.enabled}
+            checked={layoutState.quality.enabled}
             type="checkbox"
-            onChange={(e) => setQuality({ ...quality, enabled: e.target.checked })}
+            onChange={(e) => setQuality({ ...layoutState.quality, enabled: e.target.checked })}
           />
           <label htmlFor="qualityEnabled" className="form-check-label">
             {t("layouts.quality.enable")}
@@ -36,9 +42,9 @@ export const LayoutQualityForm: FC = () => {
           <input
             className="form-check-input"
             id="qualityGrid"
-            checked={quality.showGrid}
+            checked={layoutState.quality.showGrid}
             type="checkbox"
-            onChange={(e) => setQuality({ ...quality, showGrid: e.target.checked })}
+            onChange={(e) => setQuality({ ...layoutState.quality, showGrid: e.target.checked })}
           />
           <label htmlFor="qualityGrid" className="form-check-label">
             {t("layouts.quality.showGrid")}

--- a/packages/gephi-lite/src/core/context/dataContexts.tsx
+++ b/packages/gephi-lite/src/core/context/dataContexts.tsx
@@ -147,6 +147,7 @@ export const useSearch = makeUseAtom(CONTEXTS.search);
 export const useLayoutState = makeUseAtom(CONTEXTS.layoutState);
 export const useUser = makeUseAtom(CONTEXTS.user);
 export const useDynamicItemData = makeUseAtom(CONTEXTS.dynamicItemData);
+export const useSessionData = makeUseAtom(CONTEXTS.session);
 
 export const useSigmaActions = makeUseActions(sigmaActions);
 export const useFiltersActions = makeUseActions(filtersActions);
@@ -159,6 +160,7 @@ export const useSearchActions = makeUseActions(searchActions);
 export const useFileActions = makeUseActions(fileActions);
 export const useLayoutActions = makeUseActions(layoutActions);
 export const useUserActions = makeUseActions(userActions);
+export const useSessionActions = makeUseActions(sessionActions);
 
 export const useResetStates = () => {
   return resetStates;

--- a/packages/gephi-lite/src/core/context/eventsContext.ts
+++ b/packages/gephi-lite/src/core/context/eventsContext.ts
@@ -11,6 +11,7 @@ export const EVENTS = {
   nodeCreated: "nodeCreated",
   edgeCreated: "edgeCreated",
   searchResultsSelected: "searchResultsSelected",
+  openMenu: "openMenu",
 } as const;
 
 /**

--- a/packages/gephi-lite/src/core/layouts/collection/forceAtlas2.ts
+++ b/packages/gephi-lite/src/core/layouts/collection/forceAtlas2.ts
@@ -57,7 +57,7 @@ export const ForceAtlas2Layout = {
       description: true,
       defaultValue: FA2_DEFAULT_SETTINGS.gravity,
       min: 0,
-      step: 0.01,
+      step: "any",
       required: true,
     },
     { id: "linLogMode", type: "boolean", description: true, defaultValue: FA2_DEFAULT_SETTINGS.linLogMode },
@@ -74,7 +74,7 @@ export const ForceAtlas2Layout = {
       step: 1,
       required: true,
     },
-    { id: "slowDown", type: "number", defaultValue: FA2_DEFAULT_SETTINGS.slowDown, min: 1, step: 1 },
+    { id: "slowDown", type: "number", defaultValue: FA2_DEFAULT_SETTINGS.slowDown, min: 1, step:"any"},
     { id: "strongGravityMode", type: "boolean", defaultValue: FA2_DEFAULT_SETTINGS.strongGravityMode },
   ],
 } as WorkerLayout<ForceAtlas2LayoutParameters>;

--- a/packages/gephi-lite/src/core/layouts/index.ts
+++ b/packages/gephi-lite/src/core/layouts/index.ts
@@ -44,7 +44,7 @@ export const stopLayout = asyncAction(async (isForRestart = false) => {
     layoutState.supervisor.stop();
     layoutState.supervisor.kill();
 
-    // DOn't save position if it's for a restart
+    // Don't save position if it's for a restart
     if (!isForRestart) {
       // Save data
       const positions: LayoutMapping = {};

--- a/packages/gephi-lite/src/core/layouts/index.ts
+++ b/packages/gephi-lite/src/core/layouts/index.ts
@@ -7,7 +7,7 @@ import { localStorage } from "../../utils/storage";
 import { EVENTS, emitter } from "../context/eventsContext";
 import { graphDatasetActions, graphDatasetAtom, sigmaGraphAtom } from "../graph";
 import { dataGraphToFullGraph } from "../graph/utils";
-import { sessionActions, sessionAtom } from "../session";
+import { sessionAtom } from "../session";
 import { resetCamera } from "../sigma";
 import { LAYOUTS } from "./collection";
 import { LayoutMapping, LayoutQuality, LayoutState } from "./types";
@@ -62,19 +62,16 @@ export const stopLayout = asyncAction(async (isForRestart = false) => {
 export const startLayout = asyncAction(async (id: string, params: unknown, isForRestart = false) => {
   // Stop the previous algo (the "if needed" is done in the function itself)
   await stopLayout(isForRestart);
-  
+
   const { setNodePositions } = graphDatasetActions;
-  const { setLastLayoutUsed } = sessionActions;
 
   // search the layout
   const layout = LAYOUTS.find((l) => l.id === id);
 
   if (layout) {
-    if (!isForRestart) setLastLayoutUsed(layout.id);
-
     // Sync layout
     if (layout.type === "sync") {
-      layoutStateAtom.set((prev) => ({ ...prev, type: "running", layoutId: id }));
+      layoutStateAtom.set((prev) => ({ ...prev, type: "running", layoutId: id, supervisor: undefined }));
 
       // generate positions
       const dataset = graphDatasetAtom.get();
@@ -104,8 +101,8 @@ export const startLayout = asyncAction(async (id: string, params: unknown, isFor
 export const restartLastLayout = asyncAction(async () => {
   // Get the algo and its parameters
   const session = sessionAtom.get();
-  if (session.lastLayoutUsed) {
-    const layoutId = session.lastLayoutUsed;
+  if (session.lastLayout) {
+    const layoutId = session.lastLayout;
     const layout = LAYOUTS.find((e) => e.id === layoutId);
     const params = session.layoutsParameters[layoutId] || {};
     if (layout) {

--- a/packages/gephi-lite/src/core/layouts/index.ts
+++ b/packages/gephi-lite/src/core/layouts/index.ts
@@ -7,6 +7,7 @@ import { localStorage } from "../../utils/storage";
 import { EVENTS, emitter } from "../context/eventsContext";
 import { graphDatasetActions, graphDatasetAtom, sigmaGraphAtom } from "../graph";
 import { dataGraphToFullGraph } from "../graph/utils";
+import { sessionActions, sessionAtom } from "../session";
 import { resetCamera } from "../sigma";
 import { LAYOUTS } from "./collection";
 import { LayoutMapping, LayoutQuality, LayoutState } from "./types";
@@ -34,41 +35,7 @@ export const layoutStateAtom = atom<LayoutState>(getLocalStorageLayoutState());
  * Actions:
  * ********
  */
-export const startLayout = asyncAction(async (id: string, params: unknown) => {
-  const { setNodePositions } = graphDatasetActions;
-  const dataset = graphDatasetAtom.get();
-
-  // search the layout
-  const layout = LAYOUTS.find((l) => l.id === id);
-
-  // Sync layout
-  if (layout && layout.type === "sync") {
-    layoutStateAtom.set((prev) => ({ ...prev, type: "running", layoutId: id }));
-
-    // generate positions
-    const fullGraph = dataGraphToFullGraph(dataset);
-    const positions = layout.run(fullGraph, { settings: params });
-
-    // Save it
-    setNodePositions(positions);
-
-    // To prevent resetting the camera before sigma receives new data, we
-    // need to wait a frame, and also wait for it to trigger a refresh:
-    setTimeout(() => {
-      layoutStateAtom.set((prev) => ({ ...prev, type: "idle" }));
-      resetCamera({ forceRefresh: false });
-    }, 0);
-  }
-
-  // Async layout
-  if (layout && layout.type === "worker") {
-    const worker = new layout.supervisor(sigmaGraphAtom.get(), { settings: params });
-    worker.start();
-    layoutStateAtom.set((prev) => ({ ...prev, type: "running", layoutId: id, supervisor: worker }));
-  }
-});
-
-export const stopLayout = asyncAction(async () => {
+export const stopLayout = asyncAction(async (isForRestart = false) => {
   const { setNodePositions } = graphDatasetActions;
   const layoutState = layoutStateAtom.get();
 
@@ -77,15 +44,74 @@ export const stopLayout = asyncAction(async () => {
     layoutState.supervisor.stop();
     layoutState.supervisor.kill();
 
-    // Save data
-    const positions: LayoutMapping = {};
-    sigmaGraphAtom.get().forEachNode((node, { x, y }) => {
-      positions[node] = { x, y };
-    });
-    setNodePositions(positions);
+    // DOn't save position if it's for a restart
+    if (!isForRestart) {
+      // Save data
+      const positions: LayoutMapping = {};
+      sigmaGraphAtom.get().forEachNode((node, { x, y }) => {
+        positions[node] = { x, y };
+      });
+      setNodePositions(positions);
+    }
   }
 
-  layoutStateAtom.set((prev) => ({ ...prev, type: "idle" }));
+  // Don't set the state if it's for restart
+  if (!isForRestart) layoutStateAtom.set((prev) => ({ ...prev, type: "idle" }));
+});
+
+export const startLayout = asyncAction(async (id: string, params: unknown, isForRestart = false) => {
+  // Stop the previous algo (the "if needed" is done in the function itself)
+  await stopLayout(isForRestart);
+  
+  const { setNodePositions } = graphDatasetActions;
+  const { setLastLayoutUsed } = sessionActions;
+
+  // search the layout
+  const layout = LAYOUTS.find((l) => l.id === id);
+
+  if (layout) {
+    if (!isForRestart) setLastLayoutUsed(layout.id);
+
+    // Sync layout
+    if (layout.type === "sync") {
+      layoutStateAtom.set((prev) => ({ ...prev, type: "running", layoutId: id }));
+
+      // generate positions
+      const dataset = graphDatasetAtom.get();
+      const fullGraph = dataGraphToFullGraph(dataset);
+      const positions = layout.run(fullGraph, { settings: params });
+
+      // Save it
+      setNodePositions(positions);
+
+      // To prevent resetting the camera before sigma receives new data, we
+      // need to wait a frame, and also wait for it to trigger a refresh:
+      setTimeout(() => {
+        layoutStateAtom.set((prev) => ({ ...prev, type: "idle" }));
+        resetCamera({ forceRefresh: false });
+      }, 0);
+    }
+
+    // Async layout
+    if (layout.type === "worker") {
+      const worker = new layout.supervisor(sigmaGraphAtom.get(), { settings: params });
+      worker.start();
+      layoutStateAtom.set((prev) => ({ ...prev, type: "running", layoutId: id, supervisor: worker }));
+    }
+  }
+});
+
+export const restartLastLayout = asyncAction(async () => {
+  // Get the algo and its parameters
+  const session = sessionAtom.get();
+  if (session.lastLayoutUsed) {
+    const layoutId = session.lastLayoutUsed;
+    const layout = LAYOUTS.find((e) => e.id === layoutId);
+    const params = session.layoutsParameters[layoutId] || {};
+    if (layout) {
+      await startLayout(layoutId, params, true);
+    }
+  }
 });
 
 export const setQuality: Producer<LayoutState, [LayoutQuality]> = (quality) => {
@@ -105,8 +131,9 @@ const _computeLayoutQualityMetric: Producer<LayoutState> = () => {
 };
 
 export const layoutActions = {
-  startLayout,
   stopLayout,
+  startLayout,
+  restartLastLayout,
   setQuality: producerToAction(setQuality, layoutStateAtom),
   computeLayoutQualityMetric: producerToAction(_computeLayoutQualityMetric, layoutStateAtom),
 };
@@ -138,5 +165,15 @@ gridEnabledAtom.bindEffect((connectedClosenessSettings) => {
     emitter.off(EVENTS.graphImported, fn);
     emitter.off(EVENTS.nodesDragged, fn);
     sigmaGraph.off("eachNodeAttributesUpdated", fn);
+  };
+});
+
+layoutStateAtom.bindEffect((state) => {
+  if (state.type !== "running") return;
+
+  const fnHandleDraggin = debounce(restartLastLayout, 100, { leading: true, trailing: true, maxWait: 100 });
+  emitter.on(EVENTS.nodesDragged, fnHandleDraggin);
+  return () => {
+    emitter.off(EVENTS.nodesDragged, fnHandleDraggin);
   };
 });

--- a/packages/gephi-lite/src/core/session/index.ts
+++ b/packages/gephi-lite/src/core/session/index.ts
@@ -18,16 +18,16 @@ export const reset: Producer<Session, []> = () => {
   return () => getEmptySession();
 };
 
-const setLastLayoutUsed: Producer<Session, [Session["lastLayoutUsed"]]> = (lastLayoutUsed) => {
+const setLastLayout: Producer<Session, [Session["lastLayout"]]> = (layoutId) => {
   return (session) => ({
     ...session,
-    lastLayoutUsed,
+    lastLayout: layoutId
   });
 };
 
 export const sessionActions = {
   reset: producerToAction(reset, sessionAtom),
-  setLastLayoutUsed: producerToAction(setLastLayoutUsed, sessionAtom),
+  setLastLayout: producerToAction(setLastLayout, sessionAtom),
 };
 
 /**

--- a/packages/gephi-lite/src/core/session/index.ts
+++ b/packages/gephi-lite/src/core/session/index.ts
@@ -5,22 +5,29 @@ import { Session } from "./types";
 import { getEmptySession, serializeSession } from "./utils";
 
 /**
- * Producers:
- * **********
- */
-
-/**
  * Public API:
  * ***********
  */
 export const sessionAtom = atom<Session>(getEmptySession());
 
+/**
+ * Producers:
+ * **********
+ */
 export const reset: Producer<Session, []> = () => {
   return () => getEmptySession();
 };
 
+const setLastLayoutUsed: Producer<Session, [Session["lastLayoutUsed"]]> = (lastLayoutUsed) => {
+  return (session) => ({
+    ...session,
+    lastLayoutUsed,
+  });
+};
+
 export const sessionActions = {
   reset: producerToAction(reset, sessionAtom),
+  setLastLayoutUsed: producerToAction(setLastLayoutUsed, sessionAtom),
 };
 
 /**

--- a/packages/gephi-lite/src/core/session/types.ts
+++ b/packages/gephi-lite/src/core/session/types.ts
@@ -1,6 +1,6 @@
 export interface Session {
+  lastLayout?: string;
   // for each layout, we save the parameters
-  lastLayoutUsed?: string;
   layoutsParameters: { [layout: string]: Record<string, unknown> };
   // for each metrics, we save the parameters
   metrics: {

--- a/packages/gephi-lite/src/core/session/types.ts
+++ b/packages/gephi-lite/src/core/session/types.ts
@@ -1,5 +1,6 @@
 export interface Session {
   // for each layout, we save the parameters
+  lastLayoutUsed?: string;
   layoutsParameters: { [layout: string]: Record<string, unknown> };
   // for each metrics, we save the parameters
   metrics: {

--- a/packages/gephi-lite/src/locales/dev.json
+++ b/packages/gephi-lite/src/locales/dev.json
@@ -355,6 +355,11 @@
     "control": {
       "fullscreenEnter": "Enter fullscreen mode",
       "fullscreenExit": "Exit fullscreen",
+      "layout-open-settings": "Open '{{name}}' layout settings",
+      "layout-no-layout": "Disabled: there is no layout in your history",
+      "layout-run-latest": "Run layout '{{name}}'",
+      "layout-start-latest": "Start layout '{{name}}'",
+      "layout-stop-latest": "Stop layout '{{name}}'",
       "zoomIn": "Zoom In",
       "zoomOut": "Zoom Out",
       "zoomReset": "See the whole graph"
@@ -506,9 +511,9 @@
     },
     "description": "This panel allows computing new coordinates to nodes of the graph. ",
     "exec": {
-      "started": "Layout {{layout}} is running",
-      "stopped": "Layout {{layout}} has been stopped",
-      "success": "Layout \"{{layout}}\" has successfully been applied."
+      "started": "Layout '{{layout}}' is running",
+      "stopped": "Layout '{{layout}}' has been stopped",
+      "success": "Layout '{{layout}}' has successfully been applied."
     },
     "fa2": {
       "buttons": {

--- a/packages/gephi-lite/src/locales/fr.json
+++ b/packages/gephi-lite/src/locales/fr.json
@@ -394,6 +394,10 @@
     "control": {
       "fullscreenEnter": "Activer le mode plein écran",
       "fullscreenExit": "Quitter le mode plein écran",
+      "layout-run-latest": "Exécuter la spatialisation '{{name}}'",
+      "layout-start-latest": "Démarrer la spatialisation '{{name}}'",
+      "layout-stop-latest": "Arrêter la spatialisation '{{name}}'",
+      "layout-open-settings": "Ouvrir le panneau de paramétrage du layout '{{name}}'",
       "zoomIn": "Zoom avant",
       "zoomOut": "Zoom arrière",
       "zoomReset": "Afficher tout le graphe"

--- a/packages/gephi-lite/src/styles/_loader.scss
+++ b/packages/gephi-lite/src/styles/_loader.scss
@@ -26,5 +26,4 @@
 
 .z-over-loader {
   z-index: 10;
-  position: relative;
 }

--- a/packages/gephi-lite/src/views/graphPage/GraphRendering.tsx
+++ b/packages/gephi-lite/src/views/graphPage/GraphRendering.tsx
@@ -87,8 +87,18 @@ const InteractionsController: FC = () => {
 
   // Get the latest layout run in the history with its data
   const lastLayoutActive = useMemo(() => {
-    if (!session.lastLayoutUsed) return null;
-    const layoutId = session.lastLayoutUsed;
+    if (!session.lastLayout) return null;
+    const layoutId = session.lastLayout;
+    
+    // Special case for layout quality
+    if(layoutId === "layout-quality") 
+      return {
+      id: "quality",
+      name: t(`layouts.${layoutId}.title`),
+      type: "quality",
+      params:{}
+    }
+
     const layout = LAYOUTS.find((e) => e.id === layoutId);
     if (!layout) return null;
 
@@ -98,7 +108,7 @@ const InteractionsController: FC = () => {
       type: layout.type,
       params: session.layoutsParameters[layout.id] || {},
     };
-  }, [session.lastLayoutUsed, session.layoutsParameters, t]);
+  }, [session.lastLayout, session.layoutsParameters, t]);
 
   // Get needed info to render the layout button
   const layoutButton = useMemo(() => {
@@ -122,6 +132,13 @@ const InteractionsController: FC = () => {
             title: t("graph.control.layout-run-latest", { name: lastLayoutActive.name }),
             icon: <PlaySyncIcon />,
             disabled: false,
+            className: "gl-btn gl-btn-icon gl-btn-outline bg-body",
+          };
+        } else if (lastLayoutActive.type === "quality") {
+          result = {
+            title: t("graph.control.layout-run-latest", { name: lastLayoutActive.name }),
+            icon: <PlaySyncIcon />,
+            disabled: true,
             className: "gl-btn gl-btn-icon gl-btn-outline bg-body",
           };
         } else {

--- a/packages/gephi-lite/src/views/graphPage/GraphRendering.tsx
+++ b/packages/gephi-lite/src/views/graphPage/GraphRendering.tsx
@@ -1,7 +1,7 @@
 import { SigmaContainer } from "@react-sigma/core";
 import { createNodeImageProgram } from "@sigma/node-image";
 import cx from "classnames";
-import { FC, useCallback, useEffect, useState } from "react";
+import { FC, type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Settings } from "sigma/settings";
 
@@ -10,19 +10,27 @@ import {
   ExitFullScreenIcon,
   FullScreenIcon,
   GraphSelectionModeIcon,
+  LayoutsIcon,
+  PauseIconFill,
+  PlayIcon,
+  PlaySyncIcon,
   ZoomInIcon,
   ZoomOutIcon,
   ZoomResetIcon,
 } from "../../components/common-icons";
 import {
   useAppearance,
+  useLayoutActions,
   useLayoutState,
   useSelection,
   useSelectionActions,
+  useSessionData,
   useSigmaAtom,
   useSigmaGraph,
   useSigmaState,
 } from "../../core/context/dataContexts";
+import { EVENTS, useEventsContext } from "../../core/context/eventsContext";
+import { LAYOUTS } from "../../core/layouts/collection";
 import { GRAPH_SELECTION_MODES } from "../../core/selection/types";
 import { resetCamera } from "../../core/sigma";
 import NodeProgramBorder from "../../utils/bordered-node-program";
@@ -60,59 +68,167 @@ function useFullScreen(): { toggle: () => void; isFullScreen: boolean } {
 
 const InteractionsController: FC = () => {
   const { t } = useTranslation();
+  const { emitter } = useEventsContext();
   const { setMode } = useSelectionActions();
   const { graphSelectionMode } = useSelection();
   const { isFullScreen, toggle } = useFullScreen();
   const sigma = useSigmaAtom();
+  const layoutState = useLayoutState();
+  const { startLayout, stopLayout } = useLayoutActions();
+  const session = useSessionData();
 
   const btnClassName = "gl-btn gl-btn-icon gl-btn-outline bg-body";
   const zoomOptions = { duration: 200, factor: 1.5 };
 
+  // Is layout is running ?
+  const isLayoutRunning = useMemo(() => {
+    return layoutState.type === "running";
+  }, [layoutState.type]);
+
+  // Get the latest layout run in the history with its data
+  const lastLayoutActive = useMemo(() => {
+    if (!session.lastLayoutUsed) return null;
+    const layoutId = session.lastLayoutUsed;
+    const layout = LAYOUTS.find((e) => e.id === layoutId);
+    if (!layout) return null;
+
+    return {
+      id: layout.id,
+      name: t(`layouts.${layout.id}.title`),
+      type: layout.type,
+      params: session.layoutsParameters[layout.id] || {},
+    };
+  }, [session.lastLayoutUsed, session.layoutsParameters, t]);
+
+  // Get needed info to render the layout button
+  const layoutButton = useMemo(() => {
+    let result: { title: string; icon: ReactNode; disabled: boolean; className: string } = {
+      title: t("graph.control.layout-no-layout"),
+      icon: <PlayIcon />,
+      disabled: true,
+      className: "gl-btn gl-btn-icon gl-btn-outline",
+    };
+    if (lastLayoutActive) {
+      if (isLayoutRunning) {
+        result = {
+          title: t("graph.control.layout-stop-latest", { name: lastLayoutActive.name }),
+          icon: <PauseIconFill />,
+          disabled: false,
+          className: "gl-btn gl-btn-icon gl-btn-fill",
+        };
+      } else {
+        if (lastLayoutActive.type === "sync") {
+          result = {
+            title: t("graph.control.layout-run-latest", { name: lastLayoutActive.name }),
+            icon: <PlaySyncIcon />,
+            disabled: false,
+            className: "gl-btn gl-btn-icon gl-btn-outline bg-body",
+          };
+        } else {
+          result = {
+            title: t("graph.control.layout-start-latest", { name: lastLayoutActive.name }),
+            icon: <PlayIcon />,
+            disabled: false,
+            className: "gl-btn gl-btn-icon gl-btn-outline bg-body",
+          };
+        }
+      }
+    }
+    return result;
+  }, [lastLayoutActive, isLayoutRunning, t]);
+
+  // Start / stop action for the layout button
+  const startStopLayout = useCallback(() => {
+    if (isLayoutRunning) stopLayout();
+    else if (lastLayoutActive) {
+      startLayout(lastLayoutActive.id, lastLayoutActive.params);
+    }
+  }, [startLayout, stopLayout, isLayoutRunning, lastLayoutActive]);
+
+  // Open the settings of the latest layout
+  // Default is FA2
+  const openMenuItem = useCallback(() => {
+    const layoutId = lastLayoutActive ? lastLayoutActive.id : "fa2";
+    emitter.emit(EVENTS.openMenu, { menuId: `layout-${layoutId}` });
+  }, [emitter, lastLayoutActive]);
+
+  // When the component is unmounted
+  // => stop the layout
+  useEffect(() => {
+    return () => {
+      stopLayout();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
-    <div className="position-absolute d-flex flex-column sigma-controls gl-gap-1" style={{ right: 10, bottom: 10 }}>
-      {GRAPH_SELECTION_MODES.map((mode) => (
+    <div className="position-absolute d-flex sigma-controls gl-gap-2" style={{ right: 10, bottom: 10 }}>
+      <div className="d-flex flex-column gl-gap-1">
+        {GRAPH_SELECTION_MODES.map((mode) => (
+          <button
+            key={mode}
+            className={cx("gl-btn gl-btn-icon", mode === graphSelectionMode ? "gl-btn-fill" : "gl-btn-outline bg-body")}
+            onClick={() => setMode(mode)}
+            title={t(`selection.${mode}`)}
+          >
+            <GraphSelectionModeIcon mode={mode} fill={mode === graphSelectionMode} />
+          </button>
+        ))}
+
+        <br className="mb-2" />
+
         <button
-          key={mode}
-          className={cx("gl-btn gl-btn-icon", mode === graphSelectionMode ? "gl-btn-fill" : "gl-btn-outline bg-body")}
-          onClick={() => setMode(mode)}
-          title={t(`selection.${mode}`)}
+          className={layoutButton.className}
+          onClick={startStopLayout}
+          disabled={layoutButton.disabled}
+          title={layoutButton.title}
         >
-          <GraphSelectionModeIcon mode={mode} fill={mode === graphSelectionMode} />
+          {layoutButton.icon}
         </button>
-      ))}
 
-      <br className="mb-2" />
+        <button
+          className={cx("gl-btn gl-btn-icon gl-btn-outline bg-body")}
+          onClick={openMenuItem}
+          title={t("graph.control.layout-open-settings", {
+            name: lastLayoutActive ? lastLayoutActive.name : t("layouts.fa2.title"),
+          })}
+        >
+          <LayoutsIcon />
+        </button>
 
-      <button
-        className={btnClassName}
-        onClick={() => sigma.getCamera().animatedZoom(zoomOptions)}
-        title={t("graph.control.zoomIn")}
-      >
-        <ZoomInIcon />
-      </button>
-      <button
-        className={btnClassName}
-        onClick={() => sigma.getCamera().animatedUnzoom(zoomOptions)}
-        title={t("graph.control.zoomOut")}
-      >
-        <ZoomOutIcon />
-      </button>
-      <button
-        className={btnClassName}
-        onClick={() => resetCamera({ forceRefresh: true, source: "sigma" })}
-        title={t("graph.control.zoomReset")}
-      >
-        <ZoomResetIcon />
-      </button>
-      {document.fullscreenEnabled && (
+        <br className="mb-2" />
+
         <button
           className={btnClassName}
-          onClick={() => toggle()}
-          title={isFullScreen ? t("graph.control.fullscreenExit") : t("graph.control.fullscreenEnter")}
+          onClick={() => sigma.getCamera().animatedZoom(zoomOptions)}
+          title={t("graph.control.zoomIn")}
         >
-          {isFullScreen ? <ExitFullScreenIcon /> : <FullScreenIcon />}
+          <ZoomInIcon />
         </button>
-      )}
+        <button
+          className={btnClassName}
+          onClick={() => sigma.getCamera().animatedUnzoom(zoomOptions)}
+          title={t("graph.control.zoomOut")}
+        >
+          <ZoomOutIcon />
+        </button>
+        <button
+          className={btnClassName}
+          onClick={() => resetCamera({ forceRefresh: true, source: "sigma" })}
+          title={t("graph.control.zoomReset")}
+        >
+          <ZoomResetIcon />
+        </button>
+        {document.fullscreenEnabled && (
+          <button
+            className={btnClassName}
+            onClick={() => toggle()}
+            title={isFullScreen ? t("graph.control.fullscreenExit") : t("graph.control.fullscreenEnter")}
+          >
+            {isFullScreen ? <ExitFullScreenIcon /> : <FullScreenIcon />}
+          </button>
+        )}
+      </div>
     </div>
   );
 };

--- a/packages/gephi-lite/src/views/graphPage/controllers/EventsController.tsx
+++ b/packages/gephi-lite/src/views/graphPage/controllers/EventsController.tsx
@@ -129,6 +129,7 @@ export const EventsController: FC = () => {
 
           for (const node in dragState.initialNodesPosition) {
             const initialPosition = dragState.initialNodesPosition[node];
+            graph.setNodeAttribute(node, "fixed", true);
             graph.setNodeAttribute(node, "x", initialPosition.x + delta.x);
             graph.setNodeAttribute(node, "y", initialPosition.y + delta.y);
           }

--- a/packages/gephi-lite/src/views/graphPage/controllers/EventsController.tsx
+++ b/packages/gephi-lite/src/views/graphPage/controllers/EventsController.tsx
@@ -6,6 +6,7 @@ import { Coordinates, MouseCoords } from "sigma/types";
 
 import {
   useGraphDatasetActions,
+  useLayoutState,
   useSelection,
   useSelectionActions,
   useSigmaActions,
@@ -26,6 +27,7 @@ export const EventsController: FC = () => {
   const { setNodePositions } = useGraphDatasetActions();
   const { select, toggle, emptySelection } = useSelectionActions();
   const { setHoveredNode, resetHoveredNode, setHoveredEdge, resetHoveredEdge } = useSigmaActions();
+  const { type: layoutStatus } = useLayoutState();
 
   const dragStateRef = useRef<
     | { type: "idle" }
@@ -94,7 +96,7 @@ export const EventsController: FC = () => {
 
         const initialNodesPosition: LayoutMapping = {};
         nodes.forEach((node) => {
-          // I think the fixed  attribute is a failed tryout to solve the drag during layout issue https://github.com/gephi/gephi-lite/issues/138
+          // Fixing the node position, it's needed while a layout is running
           graph.setNodeAttribute(node, "fixed", true);
           const { x, y } = graph.getNodeAttributes(node);
           initialNodesPosition[node] = { x, y };
@@ -147,16 +149,19 @@ export const EventsController: FC = () => {
       if (dragState.type === "downing" || dragState.type === "dragging") {
         const graph = sigma.getGraph();
         if (dragState.type === "dragging") {
-          // Save new positions in graph dataset:
-          const positions = mapValues(dragState.initialNodesPosition, (_initialPosition, id) =>
-            pick(graph.getNodeAttributes(id), ["x", "y"]),
-          );
-          setNodePositions(positions);
+          // Save new positions in graph dataset if layout is not running
+          // Positions will be saved when the algo will be stopped and saving positions here
+          // will retrigger the layout with the initial positions (#138)
+          if (layoutStatus !== "running") {
+            const positions = mapValues(dragState.initialNodesPosition, (_initialPosition, id) =>
+              pick(graph.getNodeAttributes(id), ["x", "y"]),
+            );
+            setNodePositions(positions);
+          }
 
           resetHoveredNode();
           resetHoveredEdge();
         }
-        // I think the fixed  attribute is a failed tryout to solve the drag during layout issue https://github.com/gephi/gephi-lite/issues/138
         graph.forEachNode((node) => graph.setNodeAttribute(node, "fixed", false));
         dragStateRef.current = { type: "idle" };
       }
@@ -179,6 +184,7 @@ export const EventsController: FC = () => {
     toggle,
     setNodePositions,
     globalEmitter,
+    layoutStatus,
   ]);
 
   // DOM events not handled by sigma:

--- a/packages/gephi-lite/src/views/graphPage/index.tsx
+++ b/packages/gephi-lite/src/views/graphPage/index.tsx
@@ -1,5 +1,5 @@
 import cx from "classnames";
-import { type ComponentType, FC, useEffect, useState } from "react";
+import { type ComponentType, FC, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { PiX } from "react-icons/pi";
 
@@ -24,7 +24,7 @@ import {
   MetricsIconFill,
 } from "../../components/common-icons";
 import { LayoutQualityForm } from "../../components/forms/LayoutQualityForm";
-import { useSelection, useSelectionActions } from "../../core/context/dataContexts";
+import { useLayoutState, useSelection, useSelectionActions } from "../../core/context/dataContexts";
 import { EVENTS, useEventsContext } from "../../core/context/eventsContext";
 import { LAYOUTS } from "../../core/layouts/collection";
 import { EDGE_METRICS, MIXED_METRICS, NODE_METRICS } from "../../core/metrics/collections";
@@ -113,9 +113,27 @@ export const GraphPage: FC = () => {
   const [selectedTool, setSelectedTool] = useState<undefined | { id: string; panel: ComponentType }>(undefined);
   const { items } = useSelection();
   const { emptySelection } = useSelectionActions();
+  const layoutState = useLayoutState();
   const { t } = useTranslation();
   const isMobile = useMobile();
   const { emitter } = useEventsContext();
+
+  const menuExtended:MenuItem<{ panel?: ComponentType, isRunning?:boolean }>[] = useMemo(
+    () =>
+      MENU.map((section) => {
+        if (section.id === "layout" && layoutState.type === "running" && "children" in section) {
+          return {
+            ...section,
+            children: section.children.map((item) => ({
+              ...item,
+              isRunning: `layout-${layoutState.layoutId}` === item.id,
+            })),
+          };
+        }
+        return section;
+      }),
+    [layoutState],
+  );
 
   // Mobile display:
   const [expanded, setExpanded] = useState(false);
@@ -190,7 +208,7 @@ export const GraphPage: FC = () => {
             <GraphSummary />
             <GraphSearchSelection />
             <SideMenu
-              menu={MENU}
+              menu={menuExtended}
               selected={selectedTool?.id}
               onSelectedChange={(item) =>
                 setSelectedTool(

--- a/packages/gephi-lite/src/views/graphPage/index.tsx
+++ b/packages/gephi-lite/src/views/graphPage/index.tsx
@@ -25,6 +25,7 @@ import {
 } from "../../components/common-icons";
 import { LayoutQualityForm } from "../../components/forms/LayoutQualityForm";
 import { useSelection, useSelectionActions } from "../../core/context/dataContexts";
+import { EVENTS, useEventsContext } from "../../core/context/eventsContext";
 import { LAYOUTS } from "../../core/layouts/collection";
 import { EDGE_METRICS, MIXED_METRICS, NODE_METRICS } from "../../core/metrics/collections";
 import { useMobile } from "../../hooks/useMobile";
@@ -93,7 +94,7 @@ const MENU: MenuItem<{ panel?: ComponentType }>[] = [
       { type: "mixed", metrics: MIXED_METRICS },
     ].flatMap(({ type, metrics }) => [
       {
-        id: type,
+        id: `metric-${type}`,
         type: "text",
         i18nKey: `graph.model.${type}`,
         className: "gl-heading-3",
@@ -114,6 +115,7 @@ export const GraphPage: FC = () => {
   const { emptySelection } = useSelectionActions();
   const { t } = useTranslation();
   const isMobile = useMobile();
+  const { emitter } = useEventsContext();
 
   // Mobile display:
   const [expanded, setExpanded] = useState(false);
@@ -135,6 +137,29 @@ export const GraphPage: FC = () => {
   useEffect(() => {
     setExpanded(false);
   }, [items]);
+
+  /**
+   * Listening to events for opening a menu item.
+   * Used in the graph controller layout button
+   */
+  useEffect(() => {
+    const menu_items = MENU.flatMap((item) => {
+      if ("children" in item) return [item, ...item.children];
+      return item;
+    });
+    const fn = ({ menuId }: { menuId: string }) => {
+      const itemToOpen = menu_items.find((e) => e.id === menuId);
+      if (itemToOpen && itemToOpen.panel)
+        setSelectedTool({
+          id: itemToOpen.id,
+          panel: itemToOpen.panel,
+        });
+    };
+    emitter.on(EVENTS.openMenu, fn);
+    return () => {
+      emitter.off(EVENTS.openMenu, fn);
+    };
+  }, [emitter, setSelectedTool]);
 
   return (
     <>
@@ -187,7 +212,7 @@ export const GraphPage: FC = () => {
             <>
               <button
                 type="button"
-                className="gl-btn-close gl-btn d-none d-sm-block"
+                className="gl-btn-close gl-btn d-none d-sm-block  z-over-loader"
                 aria-label={t("common.close")}
                 onClick={() => setSelectedTool(undefined)}
               >

--- a/packages/gephi-lite/src/views/graphPage/panels/layouts/LayoutForm.tsx
+++ b/packages/gephi-lite/src/views/graphPage/panels/layouts/LayoutForm.tsx
@@ -7,7 +7,6 @@ import Highlight from "react-highlight";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router";
 
-import { LoaderFill } from "../../../../components/Loader";
 import MessageAlert from "../../../../components/MessageAlert";
 import {
   CodeEditorIcon,
@@ -27,7 +26,7 @@ import { sessionAtom } from "../../../../core/session";
 
 export const LayoutForm: FC<{
   layout: Layout;
-  onStart: (params: Record<string, unknown>) => void;
+  onStart: (params: Record<string, unknown>, restart?:boolean) => void;
   onStop: () => void;
   isRunning: boolean;
 }> = ({ layout, onStart, onStop, isRunning }) => {
@@ -74,8 +73,16 @@ export const LayoutForm: FC<{
         errors[param.id] = t(`error.form.max`, { ...param, name });
     });
 
-    setErrors(Object.keys(errors).length > 0 ? errors : null);
-  }, [layout, layoutParameters, t]);
+    const hasError = Object.keys(errors).length > 0 
+    setErrors(hasError ? errors : null);
+
+    if(layout.type === "worker" && !hasError && isRunning){
+      onStart(layoutParameters, true);
+
+    } 
+    // I don't want to trigger this useeffect when the isRunning value changed
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [layout, layoutParameters, t, onStart]);
 
   /**
    * When the layout change
@@ -187,7 +194,6 @@ export const LayoutForm: FC<{
                       param.description ? t(`layouts.${layout.id}.parameters.${param.id}.description`) : undefined
                     }
                     value={value as number}
-                    disabled={isRunning}
                     onChange={(v) => changeParameter(param.id, v)}
                     required={param.required || false}
                     min={param.min}
@@ -203,7 +209,6 @@ export const LayoutForm: FC<{
                       param.description ? t(`layouts.${layout.id}.parameters.${param.id}.description`) : undefined
                     }
                     value={!!value as boolean}
-                    disabled={isRunning}
                     onChange={(v) => changeParameter(param.id, v)}
                     required={param.required || false}
                   />
@@ -218,7 +223,6 @@ export const LayoutForm: FC<{
                     }
                     placeholder={t("common.none")}
                     value={value as string}
-                    disabled={isRunning}
                     onChange={(v) => changeParameter(param.id, v)}
                     options={((param.itemType === "nodes" ? nodeFields : edgeFields) as FieldModel[])
                       .filter((field) => (param.restriction ? param.restriction.includes(field.type) : true))
@@ -286,7 +290,6 @@ export const LayoutForm: FC<{
               </div>
             );
           })}
-          {isRunning && <LoaderFill />}
         </div>
       </div>
 
@@ -324,7 +327,6 @@ export const LayoutForm: FC<{
                 const graph = getFilteredDataGraph(dataset, sigmaGraph);
                 setParameters(getSettings(layoutParameters, graph));
               }}
-              disabled={isRunning}
             >
               <GuessSettingsIcon />
             </button>
@@ -334,7 +336,6 @@ export const LayoutForm: FC<{
             title={t("common.reset")}
             className="gl-btn gl-btn-outline gl-btn-icon"
             onClick={() => setParameters()}
-            disabled={isRunning}
           >
             <ResetIcon />
           </button>

--- a/packages/gephi-lite/src/views/graphPage/panels/layouts/LayoutForm.tsx
+++ b/packages/gephi-lite/src/views/graphPage/panels/layouts/LayoutForm.tsx
@@ -13,9 +13,9 @@ import {
   CodeEditorIcon,
   ExternalLinkIcon,
   GuessSettingsIcon,
+  PauseIconFill,
   PlayIconFill,
   ResetIcon,
-  StopIconFill,
 } from "../../../../components/common-icons";
 import { BooleanInput, EnumInput, NumberInput } from "../../../../components/forms/TypedInputs";
 import { FunctionEditorModal } from "../../../../components/modals/FunctionEditor";
@@ -27,7 +27,6 @@ import { sessionAtom } from "../../../../core/session";
 
 export const LayoutForm: FC<{
   layout: Layout;
-  onCancel: () => void;
   onStart: (params: Record<string, unknown>) => void;
   onStop: () => void;
   isRunning: boolean;
@@ -341,20 +340,17 @@ export const LayoutForm: FC<{
           </button>
 
           <button type="submit" className="gl-btn gl-btn-fill" disabled={errors !== null}>
-            {layout.type === "sync" && <>{t("common.apply")}</>}
-            {layout.type === "worker" && (
+            {isRunning && (
               <>
-                {isRunning ? (
-                  <>
-                    <StopIconFill />
-                    {t("common.stop")}
-                  </>
-                ) : (
-                  <>
-                    <PlayIconFill />
-                    {t("common.start")}
-                  </>
-                )}
+                <PauseIconFill />
+                {t("common.stop")}
+              </>
+            )}
+            {!isRunning && layout.type === "sync" && <>{t("common.apply")}</>}
+            {!isRunning && layout.type === "worker" && (
+              <>
+                <PlayIconFill />
+                {t("common.start")}
               </>
             )}
           </button>

--- a/packages/gephi-lite/src/views/graphPage/panels/layouts/LayoutPanel.tsx
+++ b/packages/gephi-lite/src/views/graphPage/panels/layouts/LayoutPanel.tsx
@@ -1,4 +1,4 @@
-import { type FC, useEffect } from "react";
+import { type FC } from "react";
 
 import { useLayoutActions, useLayoutState } from "../../../../core/context/dataContexts";
 import type { Layout } from "../../../../core/layouts/types";
@@ -8,14 +8,7 @@ import { LayoutForm } from "./LayoutForm";
 export const LayoutPanel: FC<{ layout: Layout }> = ({ layout }) => {
   const { notify } = useNotifications();
   const { startLayout, stopLayout } = useLayoutActions();
-  const { type } = useLayoutState();
-
-  useEffect(() => {
-    return () => {
-      stopLayout();
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  const layoutState = useLayoutState();
 
   return (
     <LayoutForm
@@ -30,10 +23,7 @@ export const LayoutPanel: FC<{ layout: Layout }> = ({ layout }) => {
       onStop={() => {
         stopLayout();
       }}
-      isRunning={type === "running"}
-      onCancel={() => {
-        stopLayout();
-      }}
+      isRunning={layoutState.type === "running" && layoutState.layoutId === layout.id}
     />
   );
 };

--- a/packages/gephi-lite/src/views/graphPage/panels/layouts/LayoutPanel.tsx
+++ b/packages/gephi-lite/src/views/graphPage/panels/layouts/LayoutPanel.tsx
@@ -1,28 +1,46 @@
-import { type FC } from "react";
+import { type FC, useCallback, useEffect } from "react";
 
-import { useLayoutActions, useLayoutState } from "../../../../core/context/dataContexts";
+import { useLayoutActions, useLayoutState, useSessionActions } from "../../../../core/context/dataContexts";
 import type { Layout } from "../../../../core/layouts/types";
 import { useNotifications } from "../../../../core/notifications";
 import { LayoutForm } from "./LayoutForm";
+import { debounce } from "lodash";
 
 export const LayoutPanel: FC<{ layout: Layout }> = ({ layout }) => {
   const { notify } = useNotifications();
   const { startLayout, stopLayout } = useLayoutActions();
+  const { setLastLayout } = useSessionActions();
   const layoutState = useLayoutState();
+
+  /**
+   * When the selected layout change
+   * => we set it as lastLayout in the session
+   * => we stop the running the layout (if there is one)
+   */
+  useEffect(() => {
+    setLastLayout(layout.id);
+    if (layoutState.type === "running" && layoutState.layoutId !== layout.id) {
+      stopLayout();
+    }
+  }, [layout.id, layoutState, stopLayout, setLastLayout]);
+
+  //eslint-disable-next-line react-hooks/exhaustive-deps
+  const onStart = useCallback(debounce(
+    async (params: Record<string, unknown>, restart = false) => {
+      try {
+        await startLayout(layout.id, params, restart);
+      } catch (e) {
+        notify({ type: "error", message: (e as Error).message });
+      }
+    }, 300),
+    [startLayout, layout.id, notify],
+  );
 
   return (
     <LayoutForm
       layout={layout}
-      onStart={async (params) => {
-        try {
-          await startLayout(layout.id, params);
-        } catch (e) {
-          notify({ type: "error", message: (e as Error).message });
-        }
-      }}
-      onStop={() => {
-        stopLayout();
-      }}
+      onStart={onStart}
+      onStop={stopLayout}
       isRunning={layoutState.type === "running" && layoutState.layoutId === layout.id}
     />
   );


### PR DESCRIPTION
On the graph page, you can start/stop/run the last used layout, directly on the graph.

The lastUsedLayout is store in the session using the corresponding atom.

Now when you on a layout setting page :
- you can close it even if the algo is running (the close button is on top of the loader)
- you can't change the parameters when an algo is running

Moreover, I review the node drag'n'drop feature to restart the algo while you drag.

## Pull request type

Check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

> **_NOTE:_** Try to limit your pull request to one type, submit multiple pull requests if needed.

## What is the current behavior?

Issue Number: N/A

> **_NOTE:_** Describe the current behavior that you are modifying, or link to a relevant issue.

## What is the new behavior?

> **_NOTE:_** Describe the behavior or changes that are being added by this PR.

## Other information

> **_NOTE:_** Any other information that is important to this PR such as screenshots of how the component looks before and after the change.
